### PR TITLE
Fix missing EndVertical to avoid layout Errors.

### DIFF
--- a/Packages/DependenciesHunter/Editor/DependenciesHunter.cs
+++ b/Packages/DependenciesHunter/Editor/DependenciesHunter.cs
@@ -814,6 +814,7 @@ namespace DependenciesHunter
             }
 
             GUILayout.EndScrollView();
+            GUILayout.EndVertical();
         }
 
         private void OnProjectChange()


### PR DESCRIPTION
This modification fix this layout error.
"GUI Error: Invalid GUILayout state in SelectedAssetsReferencesWindow view. Verify that all layout Begin/End calls match
UnityEngine.GUIUtility:ProcessEvent (int,intptr,bool&)"