### PR TITLE
Changed capitalization in "Find References In Project"

### DIFF
--- a/Packages/DependenciesHunter/Editor/DependenciesHunter.cs
+++ b/Packages/DependenciesHunter/Editor/DependenciesHunter.cs
@@ -704,7 +704,7 @@ namespace DependenciesHunter
         private Vector2 _scrollPos = Vector2.zero;
         private Vector2[] _foldoutsScrolls;
 
-        [MenuItem("Assets/Find References in Project", false, 20)]
+        [MenuItem("Assets/Find References In Project", false, 20)]
         public static void FindReferences()
         {
             var window = GetWindow<SelectedAssetsReferencesWindow>();


### PR DESCRIPTION
This is a pretty pedantic pull request, but I thought about changing the capitalization here so it matches Unity's "Find References In Scene"

![image](https://user-images.githubusercontent.com/2540830/203652610-853c484f-af5d-48f8-b913-85ab187ba99d.png)

Thanks for this lovely tool!
