### PR TITLE
Added addressables as an optional reference

### DIFF
--- a/Packages/DependenciesHunter/Editor/DependenciesHunter.Editor.asmdef
+++ b/Packages/DependenciesHunter/Editor/DependenciesHunter.Editor.asmdef
@@ -1,6 +1,10 @@
 {
     "name": "DependenciesHunter.Editor",
-    "references": [],
+    "rootNamespace": "",
+    "references": [
+        "GUID:9e24947de15b9834991c9d8411ea37cf",
+        "GUID:69448af7b92c7f342b298e06a37122aa"
+    ],
     "includePlatforms": [
         "Editor"
     ],


### PR DESCRIPTION
Addressing #8 and adding support for addressables when using this repo as a remote package in other Unity projects.

How the Assembly Definition file looks when in a project that contains Addressables: 
![image](https://user-images.githubusercontent.com/20073691/226088648-fd34b552-415e-46e0-8b58-d111c0dc9109.png)

How it looks when in a project that DOES NOT have the Addressables package:
![image](https://user-images.githubusercontent.com/20073691/226088687-c3759855-bb3a-4d04-b84b-46d9c2be7942.png)

You still need to define the HUNT_ADDRESSABLES symbol if you want to have the ability of searching trhough Addressables, but it can also be defined in Project Settings instead of editing the script (you can't edit scripts if they're from a remote package):
![image](https://user-images.githubusercontent.com/20073691/226089157-feef4dbf-d51c-4c71-8fc6-e979713c1e1a.png)

This way you can use the package from the Package Manager with no problems whatsoever:
```
    "com.unity.timeline": "1.6.4",
    "com.unity.ugui": "1.0.0",
    "com.unity.visualscripting": "1.7.8",
    ...
    "unity-dependencies-hunter": "https://github.com/AlexeyPerov/Unity-Dependencies-Hunter.git#upm",
    ...
    "com.unity.modules.ai": "1.0.0",
    "com.unity.modules.androidjni": "1.0.0",
    "com.unity.modules.animation": "1.0.0",
```