### PR TITLE
Auto-define HUNT_ADDRESSABLES if addressables package is installed in the project

### DIFF
--- a/Packages/DependenciesHunter/Editor/DependenciesHunter.Editor.asmdef
+++ b/Packages/DependenciesHunter/Editor/DependenciesHunter.Editor.asmdef
@@ -14,6 +14,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.addressables",
+            "expression": "",
+            "define": "HUNT_ADDRESSABLES"
+        }
+    ],
     "noEngineReferences": false
 }


### PR DESCRIPTION
This PR utilizes the _version defines_ feature of assembly definitions to automatically define `HUNT_ADDRESSABLES` if the addressables package is installed in the project.

See [here](https://docs.unity3d.com/Manual/ScriptCompilationAssemblyDefinitionFiles.html) for details of version defines. Look for the _Defining symbols based on Unity and project package versions_ header.