### PR TITLE
Update DependenciesHunter.cs

### DIFF
--- a/Packages/DependenciesHunter/Editor/DependenciesHunter.cs
+++ b/Packages/DependenciesHunter/Editor/DependenciesHunter.cs
@@ -7,7 +7,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
-using Unity.VisualScripting;
+//using Unity.VisualScripting;
 using UnityEditor;
 #if UNITY_2021_2_OR_NEWER
 using UnityEditor.Build;


### PR DESCRIPTION
VisualScripting is not needed (and not available from Unity >= 2022).