### PR TITLE
Changed the name of clashing menu item

### DIFF
--- a/Packages/DependenciesHunter/Editor/DependenciesHunter.cs
+++ b/Packages/DependenciesHunter/Editor/DependenciesHunter.cs
@@ -784,7 +784,7 @@ namespace DependenciesHunter
         private Vector2 _scrollPos = Vector2.zero;
         private Vector2[] _foldoutsScrolls;
 
-        [MenuItem("Assets/Find References In Project", false, 20)]
+        [MenuItem("Assets/DH - Find References In Project", false, 20)]
         public static void FindReferences()
         {
             var window = GetWindow<SelectedAssetsReferencesWindow>();

--- a/Packages/DependenciesHunter/Editor/DependenciesHunter.cs
+++ b/Packages/DependenciesHunter/Editor/DependenciesHunter.cs
@@ -784,6 +784,7 @@ namespace DependenciesHunter
         private Vector2 _scrollPos = Vector2.zero;
         private Vector2[] _foldoutsScrolls;
 
+        // Added DH to avoid clash with Unity's built in menu item
         [MenuItem("Assets/DH - Find References In Project", false, 20)]
         public static void FindReferences()
         {

--- a/Packages/DependenciesHunter/package.json
+++ b/Packages/DependenciesHunter/package.json
@@ -10,6 +10,6 @@
   ],
   "author": {
     "name": "Alexey Perov",
-    "url": "https://github.com/NordlightPer/Unity-Dependencies-Hunter"
+    "url": "https://github.com/AlexeyPerov/Unity-Dependencies-Hunter"
   }
 }

--- a/Packages/DependenciesHunter/package.json
+++ b/Packages/DependenciesHunter/package.json
@@ -10,6 +10,6 @@
   ],
   "author": {
     "name": "Alexey Perov",
-    "url": "https://github.com/AlexeyPerov/Unity-Dependencies-Hunter"
+    "url": "https://github.com/NordlightPer/Unity-Dependencies-Hunter"
   }
 }


### PR DESCRIPTION
 to DH - Find References In Project to avoid clashing with Unity in newer versions (2022.3)