### PR TITLE
Fix an issue where Assets/ Short Path would often fail to provide the

### DIFF
--- a/Packages/DependenciesHunter/Editor/DependenciesHunter.cs
+++ b/Packages/DependenciesHunter/Editor/DependenciesHunter.cs
@@ -39,7 +39,7 @@ namespace DependenciesHunter
             int deletedAssetCount = 0;
             foreach (AssetData resultAsset in assets)
             {
-                bool hasDeletedAsset = AssetDatabase.DeleteAsset("Assets/" + resultAsset.ShortPath);
+                bool hasDeletedAsset = AssetDatabase.DeleteAsset(resultAsset.Path);
                 if (hasDeletedAsset)
                 {
                     deletedAssetCount += 1;


### PR DESCRIPTION
correct address. Use just .Path() instead

---

This button was failing to delete most of the assets. After debugging, I found that "Assets/" +  ShortPath() was not giving the correct address in many cases. Changing to just Path() seems to fix it. 