### PR TITLE
Use item count to determine size of dependencies scroll view

### DIFF
--- a/Packages/DependenciesHunter/Editor/DependenciesHunter.cs
+++ b/Packages/DependenciesHunter/Editor/DependenciesHunter.cs
@@ -869,7 +869,8 @@ namespace DependenciesHunter
 
                 if (_selectedObjectsFoldouts[i])
                 {
-                    _foldoutsScrolls[i] = GUILayout.BeginScrollView(_foldoutsScrolls[i]);
+                    const float itemHeight = 18f;
+                    _foldoutsScrolls[i] = GUILayout.BeginScrollView(_foldoutsScrolls[i], GUILayout.MinHeight(dependencies.Count * itemHeight + TabLength));
 
                     foreach (var resultPath in dependencies)
                     {
@@ -884,7 +885,7 @@ namespace DependenciesHunter
                         var alignment = GUI.skin.button.alignment;
                         GUI.skin.button.alignment = TextAnchor.MiddleLeft;
 
-                        if (GUILayout.Button(guiContent, GUILayout.MinWidth(300f), GUILayout.Height(18f)))
+                        if (GUILayout.Button(guiContent, GUILayout.MinWidth(300f), GUILayout.Height(itemHeight)))
                         {
                             Selection.objects = new[] {AssetDatabase.LoadMainAssetAtPath(resultPath)};
                         }


### PR DESCRIPTION
Thanks for a great tool!

I mostly use the Find References In Project button to hunt down unused assets. The list of references can be hard to read when you are looking at multiple assets with multiple references because the scroll view doesn't scale with the contents. I'm not what you intended here but my change makes it so that it takes the content size into account and it works great for me.

Peace!